### PR TITLE
Update card when finishing a task.

### DIFF
--- a/activity-manager.js
+++ b/activity-manager.js
@@ -441,27 +441,39 @@ class ActivityManagerCard extends LitElement {
         this.requestUpdate();
     }
 
-    _updateActivity() {
+    async _updateActivity() {
         if (this._currentItem == null) return;
 
-        let last_completed = this.shadowRoot.querySelector(
-            "#update-last-completed"
-        );
+        const lastCompletedEl = this.shadowRoot.querySelector("#update-last-completed");
 
-        this._hass.callWS({
-            type: "activity_manager/update",
-            item_id: this._currentItem["id"],
-            last_completed: last_completed.value,
-        });
+        try {
+            await this._hass.callWS({
+                type: "activity_manager/update",
+                item_id: this._currentItem.id,
+                last_completed: lastCompletedEl.value,
+            });
+        } finally {
+            const dlg = this.shadowRoot.querySelector(".confirm-update");
+            if (dlg) dlg.close();
+            this._currentItem = null;
+            await this._fetchData();
+        }
     }
 
-    _removeActivity() {
+    async _removeActivity() {
         if (this._currentItem == null) return;
 
-        this._hass.callWS({
-            type: "activity_manager/remove",
-            item_id: this._currentItem["id"],
-        });
+        try {
+            await this._hass.callWS({
+                type: "activity_manager/remove",
+                item_id: this._currentItem.id,
+            });
+        } finally {
+            const dlg = this.shadowRoot.querySelector(".confirm-remove");
+            if (dlg) dlg.close();
+            this._currentItem = null;
+            await this._fetchData();
+        }
     }
 
     static styles = css`


### PR DESCRIPTION
When only showing activites that are due, finishing a task did not update the card. This change updates the card after you complete a task

DISCLAIMER: This change was made with cursor AI. 
I have tested it myself and it seems to work.

Refactor activity update and removal methods to use async/await for better error handling and ensure UI updates after operations.