### PR TITLE
Fix Due Soon threshold ignored by show-due-only filter

### DIFF
--- a/activity-manager.js
+++ b/activity-manager.js
@@ -185,7 +185,7 @@ class ActivityManagerCard extends LitElement {
                 return { ...item, due, difference, _status: statusClass({ difference }, soonMs) };
             })
             .filter((item) => !this._config.category || item.category === this._config.category)
-            .filter((item) => !this._config.showDueOnly || item.difference < 0)
+            .filter((item) => !this._config.showDueOnly || item._status !== "ok")
             .sort((a, b) => {
                 if (this._config.sortBy === "name") {
                     return a.name.toLowerCase().localeCompare(b.name.toLowerCase());


### PR DESCRIPTION
## Problem

The **"Only show overdue/due-soon activities"** toggle (`showDueOnly`) filtered to overdue items only (`item.difference < 0`), never consulting the `soonHours` threshold. Activities within the due-soon window were silently hidden when the toggle was on — so a large threshold (e.g. 1000 hours) showed nothing extra, while turning the toggle off revealed many soon-due activities.

## Fix

Reuse the already-computed `_status` (`overdue`/`soon`/`ok` from `statusClass`) so the filter keeps overdue **and** due-soon items, and stays in agreement with the status coloring:

```js
.filter((item) => !this._config.showDueOnly || item._status !== "ok")
```

`_status` is `ok` only when an item is neither overdue nor within `soonMs`, so this keeps exactly the overdue + due-soon set.

## Testing

Verified in the `ha-test` instance:
- Toggle ON + threshold 1000h → due-soon activities now appear (the issue repro).
- Toggle ON + threshold 1h → only overdue + items due within the hour.
- Toggle OFF → all activities show (unchanged).
- Due-soon items keep their existing "soon" status styling.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)